### PR TITLE
Add React Native renderer path and app-native shell

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,24 @@
         "typescript": "^5.7.0",
       },
     },
+    "packages/app-native": {
+      "name": "@paved/app-native",
+      "version": "0.1.0",
+      "dependencies": {
+        "@paved/chain": "workspace:*",
+        "@paved/game-core": "workspace:*",
+        "@paved/renderer": "workspace:*",
+        "@paved/ui": "workspace:*",
+        "react": "^19.0.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-test-renderer": "^19.0.0",
+        "react-test-renderer": "^19.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0",
+      },
+    },
     "packages/app-web": {
       "name": "@paved/app-web",
       "version": "0.1.0",
@@ -408,6 +426,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
+
+    "@paved/app-native": ["@paved/app-native@workspace:packages/app-native"],
 
     "@paved/app-web": ["@paved/app-web@workspace:packages/app-web"],
 
@@ -843,6 +863,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
+
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
@@ -859,19 +881,19 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
-    "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
-    "@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
 
-    "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
-    "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
@@ -965,7 +987,7 @@
 
     "color2k": ["color2k@2.0.3", "", {}, "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="],
 
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "complex.js": ["complex.js@2.4.3", "", {}, "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ=="],
 
@@ -1183,7 +1205,7 @@
 
     "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
@@ -1383,7 +1405,7 @@
 
     "react-freeze": ["react-freeze@1.0.4", "", { "peerDependencies": { "react": ">=17.0.0" } }, "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA=="],
 
-    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+    "react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
 
     "react-native": ["react-native@0.84.0", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.84.0", "@react-native/codegen": "0.84.0", "@react-native/community-cli-plugin": "0.84.0", "@react-native/gradle-plugin": "0.84.0", "@react-native/js-polyfills": "0.84.0", "@react-native/normalize-colors": "0.84.0", "@react-native/virtualized-lists": "0.84.0", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.32.0", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "hermes-compiler": "250829098.0.7", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.3", "metro-source-map": "^0.83.3", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.27.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "tinyglobby": "^0.2.15", "whatwg-fetch": "^3.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.1", "react": "^19.2.3" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-CcBfucLDHz8MAjQx9kFXasYtpcn8zP1YapUgGtAy0psRZTLShwF9yeh5+ErSgEK2gXV1CCSz7hqCZqx1eMyBLA=="],
 
@@ -1400,6 +1422,8 @@
     "react-router": ["react-router@7.13.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA=="],
 
     "react-router-dom": ["react-router-dom@7.13.1", "", { "dependencies": { "react-router": "7.13.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.4", "", { "dependencies": { "react-is": "^19.2.4", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-Ttl5D7Rnmi6JGMUpri4UjB4BAN0FPs4yRDnu2XSsigCWOLm11o8GwRlVsh27ER+4WFqsGtrBuuv5zumUaRCmKw=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
@@ -1463,7 +1487,7 @@
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
-    "source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -1515,13 +1539,13 @@
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
-    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
 
-    "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
@@ -1601,7 +1625,7 @@
 
     "vite-plugin-wasm": ["vite-plugin-wasm@3.5.0", "", { "peerDependencies": { "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7" } }, "sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ=="],
 
-    "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "vlq": ["vlq@1.0.1", "", {}, "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="],
 
@@ -1647,6 +1671,8 @@
 
     "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
 
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@bufbuild/protoplugin/typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
@@ -1661,9 +1687,9 @@
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.6.0", "", {}, "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ=="],
 
-    "@paved/game-core/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+    "@paved/app-web/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
-    "@paved/renderer/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+    "@paved/ui/vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
     "@protobuf-ts/plugin/typescript": ["typescript@3.9.10", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="],
 
@@ -1680,8 +1706,6 @@
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "@testing-library/dom/pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
-
-    "@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1705,9 +1729,17 @@
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "metro/hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
 
+    "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
+
+    "metro-source-map/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+
+    "metro-symbolicate/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
     "micro-starknet/@noble/curves": ["@noble/curves@1.0.0", "", { "dependencies": { "@noble/hashes": "1.3.0" } }, "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw=="],
 
@@ -1727,7 +1759,11 @@
 
     "ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
     "react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.84.0", "", {}, "sha512-7JgZyWtQ9Sz4qZvCTsURUtuv8/niEZ/iCorp7eExc3GgpBWNazPumieiUoWPdgRKofU0Bqpr2/dJevEn2hrlwA=="],
+
+    "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "react-native/memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 
@@ -1745,13 +1781,7 @@
 
     "send/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
-
-    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
-
-    "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
@@ -1775,41 +1805,41 @@
 
     "@latticexyz/schema-type/viem/ws": ["ws@8.13.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="],
 
-    "@paved/game-core/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+    "@paved/app-web/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 
-    "@paved/game-core/vitest/@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+    "@paved/app-web/vitest/@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
 
-    "@paved/game-core/vitest/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+    "@paved/app-web/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
 
-    "@paved/game-core/vitest/@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+    "@paved/app-web/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
 
-    "@paved/game-core/vitest/@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+    "@paved/app-web/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
 
-    "@paved/game-core/vitest/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+    "@paved/app-web/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
 
-    "@paved/game-core/vitest/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+    "@paved/app-web/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
 
-    "@paved/game-core/vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+    "@paved/app-web/vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
-    "@paved/game-core/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+    "@paved/app-web/vitest/tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
 
-    "@paved/renderer/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+    "@paved/ui/vitest/@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 
-    "@paved/renderer/vitest/@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+    "@paved/ui/vitest/@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
 
-    "@paved/renderer/vitest/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+    "@paved/ui/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
 
-    "@paved/renderer/vitest/@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+    "@paved/ui/vitest/@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
 
-    "@paved/renderer/vitest/@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+    "@paved/ui/vitest/@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
 
-    "@paved/renderer/vitest/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+    "@paved/ui/vitest/@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
 
-    "@paved/renderer/vitest/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+    "@paved/ui/vitest/@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
 
-    "@paved/renderer/vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+    "@paved/ui/vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
-    "@paved/renderer/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+    "@paved/ui/vitest/tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
@@ -1834,5 +1864,9 @@
     "@latticexyz/schema-type/viem/@scure/bip32/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
 
     "@latticexyz/schema-type/viem/@scure/bip39/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
+
+    "@paved/app-web/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "@paved/ui/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
   }
 }

--- a/packages/app-native/__tests__/game-screen-interaction.test.tsx
+++ b/packages/app-native/__tests__/game-screen-interaction.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+import { GameScreen } from "../src/GameScreen";
+import type { RenderSurfaceAdapter } from "@paved/renderer";
+
+const mockGameCanvasNative = vi.fn(() => null);
+
+vi.mock("@paved/renderer/react-native", () => ({
+  GameCanvasNative: (props: unknown) => {
+    mockGameCanvasNative(props);
+    return null;
+  },
+}));
+
+function makeSurface(): RenderSurfaceAdapter {
+  return {
+    getSize: () => ({ width: 320, height: 200 }),
+    getDevicePixelRatio: () => 2,
+    onResize: () => () => undefined,
+    bindInput: () => undefined,
+    unbindInput: () => undefined,
+  };
+}
+
+describe("GameScreen interaction", () => {
+  it("maps tile click to selected grid coordinates callback", () => {
+    const onSelectTile = vi.fn();
+
+    act(() => {
+      create(
+        <GameScreen
+          surface={makeSurface()}
+          onSelectTile={onSelectTile}
+        />
+      );
+    });
+
+    const props = mockGameCanvasNative.mock.lastCall?.[0] as any;
+
+    act(() => {
+      props.onTileClick(7, -2);
+    });
+
+    expect(onSelectTile).toHaveBeenCalledWith({ x: 7, y: -2 });
+  });
+});

--- a/packages/app-native/__tests__/game-screen-render.test.tsx
+++ b/packages/app-native/__tests__/game-screen-render.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+import { GameScreen } from "../src/GameScreen";
+import type { RenderSurfaceAdapter } from "@paved/renderer";
+
+const mockGameCanvasNative = vi.fn(() => null);
+
+vi.mock("@paved/renderer/react-native", () => ({
+  GameCanvasNative: (props: unknown) => {
+    mockGameCanvasNative(props);
+    return null;
+  },
+}));
+
+function makeSurface(): RenderSurfaceAdapter {
+  return {
+    getSize: () => ({ width: 320, height: 200 }),
+    getDevicePixelRatio: () => 2,
+    onResize: () => () => undefined,
+    bindInput: () => undefined,
+    unbindInput: () => undefined,
+  };
+}
+
+describe("GameScreen render wiring", () => {
+  it("forwards tile and character state updates to GameCanvasNative", () => {
+    const surface = makeSurface();
+    const initialTiles = [{ game_id: 1, id: 1, player_id: "0x1", plan: 1, orientation: 1, x: 0, y: 0, occupied_spot: 0, worldX: 0, worldZ: 0 }];
+    const initialCharacters = [{ gameId: 1, playerId: "0x1", index: 0, tileId: 1, spot: 1, weight: 1, power: 1, color: "#fff", worldX: 0, worldZ: 0 }];
+
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <GameScreen
+          surface={surface}
+          tiles={initialTiles as any}
+          characters={initialCharacters as any}
+          cameraMode="play"
+        />
+      );
+    });
+
+    const firstProps = mockGameCanvasNative.mock.lastCall?.[0] as any;
+    expect(firstProps.tiles).toEqual(initialTiles);
+    expect(firstProps.characters).toEqual(initialCharacters);
+    expect(firstProps.cameraMode).toBe("play");
+
+    const nextTiles = [...initialTiles, { ...initialTiles[0], id: 2, worldX: 1 }];
+    act(() => {
+      tree!.update(
+        <GameScreen
+          surface={surface}
+          tiles={nextTiles as any}
+          characters={initialCharacters as any}
+          cameraMode="showcase"
+        />
+      );
+    });
+
+    const secondProps = mockGameCanvasNative.mock.lastCall?.[0] as any;
+    expect(secondProps.tiles).toEqual(nextTiles);
+    expect(secondProps.cameraMode).toBe("showcase");
+  });
+});

--- a/packages/app-native/__tests__/resume-recovery.test.tsx
+++ b/packages/app-native/__tests__/resume-recovery.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, create } from "react-test-renderer";
+import { GameScreen } from "../src/GameScreen";
+import type { RenderSurfaceAdapter } from "@paved/renderer";
+
+const mockGameCanvasNative = vi.fn(() => null);
+
+vi.mock("@paved/renderer/react-native", () => ({
+  GameCanvasNative: (props: unknown) => {
+    mockGameCanvasNative(props);
+    return null;
+  },
+}));
+
+function makeSurface(): RenderSurfaceAdapter {
+  return {
+    getSize: () => ({ width: 320, height: 200 }),
+    getDevicePixelRatio: () => 2,
+    onResize: () => () => undefined,
+    bindInput: () => undefined,
+    unbindInput: () => undefined,
+  };
+}
+
+describe("resume recovery", () => {
+  it("requests a render tick after resume token changes", () => {
+    const fakeScene = {
+      requestRender: vi.fn(),
+    };
+
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(<GameScreen surface={makeSurface()} resumeToken={0} />);
+    });
+
+    const initialProps = mockGameCanvasNative.mock.lastCall?.[0] as any;
+    act(() => {
+      initialProps.onReady(fakeScene);
+    });
+
+    act(() => {
+      tree!.update(<GameScreen surface={makeSurface()} resumeToken={1} />);
+    });
+
+    expect(fakeScene.requestRender).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app-native/package.json
+++ b/packages/app-native/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@paved/app-native",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@paved/game-core": "workspace:*",
+    "@paved/chain": "workspace:*",
+    "@paved/ui": "workspace:*",
+    "@paved/renderer": "workspace:*",
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-test-renderer": "^19.0.0",
+    "react-test-renderer": "^19.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/app-native/src/GameScreen.tsx
+++ b/packages/app-native/src/GameScreen.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  type TileRenderData,
+  type CharacterRenderData,
+  type HoverState,
+  type CameraMode,
+  type RenderSurfaceAdapter,
+  type EffectsCapabilities,
+  type GameSceneDependencies,
+  type GameScene,
+} from "@paved/renderer";
+import { GameCanvasNative } from "@paved/renderer/react-native";
+
+export interface GameScreenProps {
+  surface: RenderSurfaceAdapter;
+  tiles?: TileRenderData[];
+  characters?: CharacterRenderData[];
+  hover?: HoverState | null;
+  availableSlots?: Array<{ x: number; y: number }>;
+  strategyMode?: boolean;
+  compassRotation?: number;
+  cameraMode?: CameraMode;
+  basePath?: string;
+  effectsCapabilities?: EffectsCapabilities;
+  resumeToken?: number;
+  createRenderer?: GameSceneDependencies["createRenderer"];
+  createCameraController?: GameSceneDependencies["createCameraController"];
+  onSelectTile?: (coords: { x: number; y: number }) => void;
+}
+
+export function GameScreen({
+  surface,
+  tiles = [],
+  characters = [],
+  hover = null,
+  availableSlots = [],
+  strategyMode = false,
+  compassRotation = 0,
+  cameraMode = "play",
+  basePath = "",
+  effectsCapabilities,
+  resumeToken = 0,
+  createRenderer,
+  createCameraController,
+  onSelectTile,
+}: GameScreenProps) {
+  const sceneRef = useRef<GameScene | null>(null);
+
+  const handleTileClick = useCallback((x: number, y: number) => {
+    onSelectTile?.({ x, y });
+  }, [onSelectTile]);
+
+  useEffect(() => {
+    if (!sceneRef.current) return;
+    sceneRef.current.requestRender();
+  }, [resumeToken]);
+
+  return (
+    <GameCanvasNative
+      surface={surface}
+      tiles={tiles}
+      characters={characters}
+      hover={hover}
+      availableSlots={availableSlots}
+      strategyMode={strategyMode}
+      compassRotation={compassRotation}
+      cameraMode={cameraMode}
+      basePath={basePath}
+      effectsCapabilities={effectsCapabilities}
+      createRenderer={createRenderer}
+      createCameraController={createCameraController}
+      onReady={(scene) => {
+        sceneRef.current = scene;
+      }}
+      onTileClick={handleTileClick}
+    />
+  );
+}

--- a/packages/app-native/src/index.ts
+++ b/packages/app-native/src/index.ts
@@ -1,0 +1,2 @@
+export { GameScreen } from "./GameScreen";
+export type { GameScreenProps } from "./GameScreen";

--- a/packages/app-native/tsconfig.json
+++ b/packages/app-native/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"]
+  },
+  "references": [
+    { "path": "../renderer" },
+    { "path": "../game-core" },
+    { "path": "../chain" },
+    { "path": "../ui" }
+  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["dist"]
+}

--- a/packages/app-native/vitest.config.ts
+++ b/packages/app-native/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@paved/renderer": resolve(__dirname, "../renderer/src/index.ts"),
+      "@paved/renderer/react-native": resolve(__dirname, "../renderer/src/react-native/index.ts"),
+    },
+  },
+  test: {
+    include: ["__tests__/**/*.test.ts", "__tests__/**/*.test.tsx"],
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});

--- a/packages/app-native/vitest.setup.ts
+++ b/packages/app-native/vitest.setup.ts
@@ -1,0 +1,1 @@
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/renderer/__tests__/camera-controller-native.test.ts
+++ b/packages/renderer/__tests__/camera-controller-native.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { NativeCameraController } from "../src/core/NativeCameraController";
+
+describe("NativeCameraController", () => {
+  it("clamps pan in play mode to board bounds", () => {
+    const controller = new NativeCameraController();
+    controller.setBoardBounds({ minX: -3, maxX: 3, minZ: -3, maxZ: 3 });
+
+    controller.applyPan(100, -100);
+
+    expect(controller.target.x).toBeGreaterThanOrEqual(-9);
+    expect(controller.target.x).toBeLessThanOrEqual(9);
+    expect(controller.target.z).toBeGreaterThanOrEqual(-9);
+    expect(controller.target.z).toBeLessThanOrEqual(9);
+  });
+
+  it("does not clamp pan in showcase mode", () => {
+    const controller = new NativeCameraController();
+    controller.setBoardBounds({ minX: -3, maxX: 3, minZ: -3, maxZ: 3 });
+    controller.setMode("showcase");
+
+    controller.applyPan(100, -100);
+
+    expect(controller.target.x).toBe(100);
+    expect(controller.target.z).toBe(-100);
+  });
+
+  it("clamps pinch distance within min/max", () => {
+    const controller = new NativeCameraController({
+      minDistance: 5,
+      maxDistance: 20,
+      initialDistance: 10,
+    });
+
+    controller.applyPinch(0.01);
+    expect(controller.getDistance()).toBe(20);
+
+    controller.applyPinch(100);
+    expect(controller.getDistance()).toBe(5);
+  });
+});

--- a/packages/renderer/__tests__/effects-profile-fallback.test.ts
+++ b/packages/renderer/__tests__/effects-profile-fallback.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  getEffectsProfile,
+  resolveEffectsProfile,
+} from "../src/core/render-profiles";
+
+describe("effects profile fallback", () => {
+  it("returns base profile when capabilities are fully supported", () => {
+    const base = getEffectsProfile("showcaseCinematic");
+    const resolved = resolveEffectsProfile("showcaseCinematic", {
+      supportsBloom: true,
+      supportsVignette: true,
+      supportsSSAO: true,
+      lowPowerDevice: false,
+    });
+
+    expect(resolved).toEqual(base);
+  });
+
+  it("disables unsupported effects", () => {
+    const resolved = resolveEffectsProfile("showcaseCinematic", {
+      supportsBloom: false,
+      supportsVignette: false,
+      supportsSSAO: false,
+      lowPowerDevice: false,
+    });
+
+    expect(resolved.ssao.enabled).toBe(false);
+    expect(resolved.bloom.strength).toBe(0);
+    expect(resolved.vignette.darkness).toBe(0);
+  });
+
+  it("reduces heavy effects on low-power devices", () => {
+    const base = getEffectsProfile("showcaseCinematic");
+    const resolved = resolveEffectsProfile("showcaseCinematic", {
+      supportsBloom: true,
+      supportsVignette: true,
+      supportsSSAO: true,
+      lowPowerDevice: true,
+    });
+
+    expect(resolved.ssao.enabled).toBe(false);
+    expect(resolved.bloom.strength).toBeLessThan(base.bloom.strength);
+    expect(resolved.vignette.darkness).toBeLessThan(base.vignette.darkness);
+  });
+});

--- a/packages/renderer/__tests__/game-scene-native-lifecycle.test.ts
+++ b/packages/renderer/__tests__/game-scene-native-lifecycle.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import * as THREE from "three";
+import { GameScene } from "../src/core/GameScene";
+import type { RenderSurfaceAdapter, SurfaceInputEvent } from "../src/core/types";
+
+function createAdapter() {
+  const boundHandlers: Array<(event: SurfaceInputEvent) => void> = [];
+  const resizeCallbacks: Array<() => void> = [];
+  const unbindInput = vi.fn();
+
+  const adapter: RenderSurfaceAdapter = {
+    getSize: () => ({ width: 320, height: 200 }),
+    getDevicePixelRatio: () => 2,
+    onResize: (cb) => {
+      resizeCallbacks.push(cb);
+      return vi.fn();
+    },
+    bindInput: (handler) => {
+      boundHandlers.push(handler);
+    },
+    unbindInput,
+  };
+
+  return { adapter, boundHandlers, resizeCallbacks, unbindInput };
+}
+
+function createScene(adapter: RenderSurfaceAdapter) {
+  const renderer = {
+    setPixelRatio: vi.fn(),
+    setSize: vi.fn(),
+    render: vi.fn(),
+    dispose: vi.fn(),
+    shadowMap: { enabled: false, type: 0 },
+    domElement: { width: 320, height: 200, toDataURL: vi.fn(() => "") },
+    outputColorSpace: "",
+    toneMapping: 0,
+    toneMappingExposure: 1,
+  };
+
+  const camera = new THREE.PerspectiveCamera(50, 1, 1, 2000);
+  camera.position.set(0, 24, 0.1);
+  camera.lookAt(0, 0, 0);
+  camera.updateMatrixWorld(true);
+
+  const controller = {
+    camera,
+    controls: { addEventListener: vi.fn(), target: new THREE.Vector3() },
+    update: vi.fn(() => false),
+    resize: vi.fn(),
+    setMode: vi.fn(),
+    setBoardBounds: vi.fn(),
+    focusBounds: vi.fn(),
+    dispose: vi.fn(),
+  };
+
+  const scene = new GameScene({
+    createRenderer: vi.fn(() => renderer as any),
+    createCameraController: vi.fn(() => controller as any),
+  });
+  (scene as any).assets.preloadAll = vi.fn().mockResolvedValue(undefined);
+  (scene as any).effects = {
+    init: vi.fn(),
+    setCapabilities: vi.fn(),
+    setProfile: vi.fn(),
+    resize: vi.fn(),
+    render: vi.fn(),
+    dispose: vi.fn(),
+  };
+
+  return { scene, renderer, controller, adapter };
+}
+
+describe("GameScene native lifecycle", () => {
+  it("does not double-bind input handlers across re-init", async () => {
+    const { adapter, boundHandlers, unbindInput } = createAdapter();
+    const { scene } = createScene(adapter);
+
+    await scene.init({ surface: adapter });
+    await scene.init({ surface: adapter });
+
+    expect(boundHandlers).toHaveLength(2);
+    expect(unbindInput).toHaveBeenCalledTimes(1);
+  });
+
+  it("unbinds listeners and disposes resources on dispose", async () => {
+    const { adapter, unbindInput } = createAdapter();
+    const { scene, renderer, controller } = createScene(adapter);
+
+    await scene.init({ surface: adapter });
+    scene.dispose();
+
+    expect(unbindInput).toHaveBeenCalledTimes(1);
+    expect(renderer.dispose).toHaveBeenCalledTimes(1);
+    expect(controller.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/renderer/__tests__/native-input-mapper.test.ts
+++ b/packages/renderer/__tests__/native-input-mapper.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { NativeInputMapper } from "../src/core/native-input-mapper";
+
+describe("NativeInputMapper", () => {
+  it("emits click for tap within threshold", () => {
+    const mapper = new NativeInputMapper({ clickThreshold: 6 });
+
+    mapper.handleStart({ pointerId: 1, x: 100, y: 100 });
+    mapper.handleMove({ pointerId: 1, x: 103, y: 102 });
+    const events = mapper.handleEnd({ pointerId: 1, x: 103, y: 102 });
+
+    expect(events).toEqual([{ type: "click", x: 103, y: 102 }]);
+  });
+
+  it("suppresses click after drag and emits pan deltas", () => {
+    const mapper = new NativeInputMapper({ clickThreshold: 4 });
+
+    mapper.handleStart({ pointerId: 1, x: 50, y: 50 });
+    const moveEvents = mapper.handleMove({ pointerId: 1, x: 62, y: 46 });
+    const endEvents = mapper.handleEnd({ pointerId: 1, x: 64, y: 45 });
+
+    expect(moveEvents).toEqual([{ type: "pan", dx: 12, dy: -4 }]);
+    expect(endEvents).toEqual([]);
+  });
+
+  it("emits pinch scale when two touches move", () => {
+    const mapper = new NativeInputMapper();
+
+    mapper.handleStart({ pointerId: 1, x: 10, y: 10 });
+    mapper.handleStart({ pointerId: 2, x: 30, y: 10 });
+
+    const events = mapper.handleMove({ pointerId: 2, x: 40, y: 10 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("pinch");
+    expect(events[0]).toMatchObject({ scale: 1.5 });
+  });
+});

--- a/packages/renderer/__tests__/surface-adapter.test.ts
+++ b/packages/renderer/__tests__/surface-adapter.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import * as THREE from "three";
+import { GameScene } from "../src/core/GameScene";
+import type { RenderSurfaceAdapter, SurfaceInputEvent } from "../src/core/types";
+
+type ResizeCallback = () => void;
+
+function createSurfaceAdapter(size = { width: 400, height: 240 }, dpr = 2): {
+  surface: RenderSurfaceAdapter;
+  emitResize: () => void;
+  emitInput: (event: SurfaceInputEvent) => void;
+  onResizeUnsubscribe: ReturnType<typeof vi.fn>;
+  unbindInput: ReturnType<typeof vi.fn>;
+} {
+  let resizeCallback: ResizeCallback = () => undefined;
+  let inputHandler: ((event: SurfaceInputEvent) => void) | null = null;
+  const onResizeUnsubscribe = vi.fn();
+  const unbindInput = vi.fn(() => {
+    inputHandler = null;
+  });
+
+  const surface: RenderSurfaceAdapter = {
+    getSize: () => size,
+    getDevicePixelRatio: () => dpr,
+    onResize: (cb) => {
+      resizeCallback = cb;
+      return onResizeUnsubscribe;
+    },
+    bindInput: (handler) => {
+      inputHandler = handler;
+    },
+    unbindInput,
+  };
+
+  return {
+    surface,
+    emitResize: () => resizeCallback(),
+    emitInput: (event) => inputHandler?.(event),
+    onResizeUnsubscribe,
+    unbindInput,
+  };
+}
+
+function createController() {
+  const camera = new THREE.PerspectiveCamera(50, 1, 1, 2000);
+  camera.position.set(0, 24, 0.1);
+  camera.lookAt(0, 0, 0);
+  camera.updateMatrixWorld(true);
+
+  return {
+    camera,
+    controls: {
+      addEventListener: vi.fn(),
+      target: new THREE.Vector3(),
+    },
+    update: vi.fn(() => false),
+    resize: vi.fn(),
+    setMode: vi.fn(),
+    setBoardBounds: vi.fn(),
+    focusBounds: vi.fn(),
+    dispose: vi.fn(),
+  };
+}
+
+function createRenderer() {
+  return {
+    setPixelRatio: vi.fn(),
+    setSize: vi.fn(),
+    render: vi.fn(),
+    dispose: vi.fn(),
+    domElement: {
+      width: 400,
+      height: 240,
+      toDataURL: vi.fn(() => "data:image/png;base64,mock"),
+    },
+    shadowMap: {
+      enabled: false,
+      type: 0,
+    },
+    outputColorSpace: "",
+    toneMapping: 0,
+    toneMappingExposure: 1,
+  };
+}
+
+function createSceneHarness() {
+  const controller = createController();
+  const renderer = createRenderer();
+
+  const scene = new GameScene({
+    createCameraController: vi.fn(() => controller as any),
+    createRenderer: vi.fn(() => renderer as any),
+  });
+
+  (scene as any).assets.preloadAll = vi.fn().mockResolvedValue(undefined);
+  (scene as any).effects = {
+    init: vi.fn(),
+    setCapabilities: vi.fn(),
+    setProfile: vi.fn(),
+    resize: vi.fn(),
+    render: vi.fn(),
+    dispose: vi.fn(),
+  };
+
+  return { scene, controller, renderer };
+}
+
+describe("RenderSurfaceAdapter integration", () => {
+  it("initializes GameScene from surface adapter (no canvas in config)", async () => {
+    const { surface } = createSurfaceAdapter({ width: 320, height: 180 }, 3);
+    const { scene, renderer } = createSceneHarness();
+
+    await scene.init({ surface, pixelRatio: [0.5, 1.5], shadows: false });
+
+    expect(renderer.setPixelRatio).toHaveBeenCalledWith(1.5);
+    expect(renderer.setSize).toHaveBeenCalledWith(320, 180);
+  });
+
+  it("uses surface resize callback to update renderer and camera", async () => {
+    const adapter = createSurfaceAdapter({ width: 300, height: 200 }, 2);
+    const { scene, controller, renderer } = createSceneHarness();
+
+    await scene.init({ surface: adapter.surface });
+
+    (adapter.surface.getSize as any) = () => ({ width: 640, height: 360 });
+    adapter.emitResize();
+
+    expect(renderer.setSize).toHaveBeenLastCalledWith(640, 360);
+    expect(controller.resize).toHaveBeenCalledWith(640, 360);
+    expect((scene as any).effects.resize).toHaveBeenCalledWith(640, 360);
+  });
+
+  it("unbinds adapter listeners during dispose", async () => {
+    const adapter = createSurfaceAdapter();
+    const { scene, controller, renderer } = createSceneHarness();
+
+    await scene.init({ surface: adapter.surface });
+    scene.dispose();
+
+    expect(adapter.unbindInput).toHaveBeenCalledTimes(1);
+    expect(adapter.onResizeUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(controller.dispose).toHaveBeenCalledTimes(1);
+    expect(renderer.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes click interactions from adapter input events", async () => {
+    const adapter = createSurfaceAdapter({ width: 400, height: 400 }, 1);
+    const { scene } = createSceneHarness();
+    const onTileClick = vi.fn();
+
+    await scene.init({ surface: adapter.surface });
+    scene.onTileClick(onTileClick);
+
+    adapter.emitInput({ type: "pointerdown", x: 200, y: 200, button: 0 });
+    adapter.emitInput({ type: "pointerup", x: 200, y: 200, button: 0 });
+
+    expect(onTileClick).toHaveBeenCalledTimes(1);
+    expect(onTileClick).toHaveBeenCalledWith(0, 0);
+  });
+});

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -13,6 +13,10 @@
     "./react": {
       "import": "./dist/react/index.js",
       "types": "./dist/react/index.d.ts"
+    },
+    "./react-native": {
+      "import": "./dist/react-native/index.js",
+      "types": "./dist/react-native/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/renderer/src/core/CameraController.ts
+++ b/packages/renderer/src/core/CameraController.ts
@@ -11,6 +11,47 @@ export interface CameraConfig {
   maxDistance?: number;
 }
 
+export interface CameraViewport {
+  width: number;
+  height: number;
+  inputTarget?: unknown;
+}
+
+export interface CameraInputAdapter {
+  target: THREE.Vector3;
+  enableRotate: boolean;
+  enablePan: boolean;
+  enableDamping: boolean;
+  zoomToCursor: boolean;
+  zoomSpeed: number;
+  panSpeed: number;
+  rotateSpeed: number;
+  minAzimuthAngle: number;
+  maxAzimuthAngle: number;
+  minPolarAngle: number;
+  maxPolarAngle: number;
+  minDistance: number;
+  maxDistance: number;
+  touches: {
+    ONE: number;
+    TWO: number;
+  };
+  mouseButtons: {
+    LEFT: number;
+    MIDDLE: number;
+    RIGHT: number;
+  };
+  addEventListener(eventName: string, callback: () => void): void;
+  update(): boolean;
+  reset(): void;
+  dispose(): void;
+}
+
+export type CameraInputAdapterFactory = (
+  camera: THREE.PerspectiveCamera,
+  inputTarget: unknown,
+) => CameraInputAdapter;
+
 const DEFAULT_CONFIG: Required<CameraConfig> = {
   position: [0, 0, 0],
   zoom: 5,
@@ -20,21 +61,49 @@ const DEFAULT_CONFIG: Required<CameraConfig> = {
   maxDistance: 300,
 };
 
+function createOrbitCameraInputAdapter(
+  camera: THREE.PerspectiveCamera,
+  inputTarget: unknown,
+): CameraInputAdapter {
+  if (!inputTarget) {
+    throw new Error("Camera input target is required for OrbitControls");
+  }
+
+  return new OrbitControls(camera, inputTarget as HTMLElement) as unknown as CameraInputAdapter;
+}
+
+function normalizeViewport(input: CameraViewport | HTMLCanvasElement): CameraViewport {
+  if ("clientWidth" in input && "clientHeight" in input) {
+    return {
+      width: input.clientWidth,
+      height: input.clientHeight,
+      inputTarget: input,
+    };
+  }
+
+  return input;
+}
+
 export class CameraController {
   private static readonly BOARD_MARGIN = 6;
 
   camera: THREE.PerspectiveCamera;
-  controls: OrbitControls;
+  controls: CameraInputAdapter;
   private compassRotation = 0;
   private mode: CameraMode = "play";
   private boardBounds: BoardBounds | null = null;
 
-  constructor(canvas: HTMLCanvasElement, config: CameraConfig = {}) {
+  constructor(
+    viewportOrCanvas: CameraViewport | HTMLCanvasElement,
+    config: CameraConfig = {},
+    createInputAdapter: CameraInputAdapterFactory = createOrbitCameraInputAdapter,
+  ) {
     const cfg = { ...DEFAULT_CONFIG, ...config };
+    const viewport = normalizeViewport(viewportOrCanvas);
 
     this.camera = new THREE.PerspectiveCamera(
       50,
-      canvas.clientWidth / canvas.clientHeight,
+      viewport.width / viewport.height,
       cfg.near,
       cfg.far
     );
@@ -43,7 +112,7 @@ export class CameraController {
     this.camera.zoom = cfg.zoom;
     this.camera.updateProjectionMatrix();
 
-    this.controls = new OrbitControls(this.camera, canvas);
+    this.controls = createInputAdapter(this.camera, viewport.inputTarget);
     this.controls.enableRotate = true;
     this.controls.enablePan = true;
     this.controls.enableDamping = true;

--- a/packages/renderer/src/core/Effects.ts
+++ b/packages/renderer/src/core/Effects.ts
@@ -4,8 +4,8 @@ import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/addons/postprocessing/UnrealBloomPass.js";
 import { ShaderPass } from "three/addons/postprocessing/ShaderPass.js";
 import { SSAOPass } from "three/addons/postprocessing/SSAOPass.js";
-import type { RenderProfile } from "./types";
-import { getEffectsProfile } from "./render-profiles";
+import type { RenderProfile, EffectsCapabilities } from "./types";
+import { resolveEffectsProfile } from "./render-profiles";
 
 // Vignette shader (from postprocessing library, simplified)
 const VignetteShader = {
@@ -68,6 +68,7 @@ export class Effects {
   private config: EffectsConfig;
   private profile: RenderProfile = "play";
   private ssaoPass: SSAOPass | null = null;
+  private capabilities: EffectsCapabilities = {};
 
   constructor(config: EffectsConfig = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config };
@@ -91,6 +92,11 @@ export class Effects {
     this.buildComposer();
   }
 
+  setCapabilities(capabilities: EffectsCapabilities): void {
+    this.capabilities = capabilities;
+    this.buildComposer();
+  }
+
   private buildComposer(): void {
     if (!this.renderer || !this.scene || !this.camera) return;
 
@@ -105,7 +111,7 @@ export class Effects {
     const renderPass = new RenderPass(scene, camera);
     this.composer.addPass(renderPass);
 
-    const profileConfig = getEffectsProfile(this.profile);
+    const profileConfig = resolveEffectsProfile(this.profile, this.capabilities);
 
     if (profileConfig.ssao.enabled) {
       this.ssaoPass = new SSAOPass(

--- a/packages/renderer/src/core/GameScene.ts
+++ b/packages/renderer/src/core/GameScene.ts
@@ -13,6 +13,8 @@ import type {
   CameraMode,
   BoardBounds,
   RenderProfile,
+  RenderSurfaceAdapter,
+  SurfaceInputEvent,
 } from "./types";
 import { TILE_SIZE } from "./types";
 import {
@@ -29,6 +31,34 @@ const SHADOW_NEAR = 1;
 const SHADOW_FAR = 100;
 const SHADOW_FRUSTUM = 50;
 
+export interface GameSceneDependencies {
+  createRenderer?: (surface: RenderSurfaceAdapter) => THREE.WebGLRenderer;
+  createCameraController?: (surface: RenderSurfaceAdapter) => CameraController;
+}
+
+function createDefaultRenderer(surface: RenderSurfaceAdapter): THREE.WebGLRenderer {
+  const renderTarget = surface.getRenderTarget?.();
+  if (!renderTarget) {
+    throw new Error("Render surface does not expose a render target");
+  }
+
+  return new THREE.WebGLRenderer({
+    canvas: renderTarget as HTMLCanvasElement,
+    antialias: true,
+    alpha: false,
+  });
+}
+
+function createDefaultCameraController(surface: RenderSurfaceAdapter): CameraController {
+  const size = surface.getSize();
+
+  return new CameraController({
+    width: size.width,
+    height: size.height,
+    inputTarget: surface.getRenderTarget?.(),
+  });
+}
+
 export class GameScene {
   scene: THREE.Scene;
   camera!: THREE.PerspectiveCamera;
@@ -39,6 +69,7 @@ export class GameScene {
   assets: AssetLoader;
   effects: Effects;
 
+  private readonly dependencies: GameSceneDependencies;
   private sceneGroup: THREE.Group;
   private animationId: number | null = null;
   private needsRender = true;
@@ -54,14 +85,11 @@ export class GameScene {
   private onTileClickCallback: ((gridX: number, gridY: number) => void) | null = null;
   private onTileHoverCallback: ((gridX: number, gridY: number) => void) | null = null;
   private onHoverLeaveCallback: (() => void) | null = null;
-  private boundPointerDown: ((e: PointerEvent) => void) | null = null;
-  private boundPointerUp: ((e: PointerEvent) => void) | null = null;
-  private boundPointerMove: ((e: PointerEvent) => void) | null = null;
-  private boundPointerLeave: (() => void) | null = null;
-  private interactionCanvas: HTMLCanvasElement | null = null;
-  private resizeObserver: ResizeObserver | null = null;
+  private boundInputHandler: ((event: SurfaceInputEvent) => void) | null = null;
+  private surface: RenderSurfaceAdapter | null = null;
+  private unbindResize: (() => void) | null = null;
 
-  constructor() {
+  constructor(dependencies: GameSceneDependencies = {}) {
     this.scene = new THREE.Scene();
     this.sceneGroup = new THREE.Group();
     this.scene.add(this.sceneGroup);
@@ -72,10 +100,30 @@ export class GameScene {
 
     this.sceneGroup.add(this.tiles.getGroup());
     this.sceneGroup.add(this.characters.getGroup());
+
+    this.dependencies = dependencies;
   }
 
   async init(config: RendererConfig): Promise<void> {
-    const { canvas, basePath, pixelRatio = [0.5, 1], shadows = true } = config;
+    const {
+      surface,
+      basePath,
+      pixelRatio = [0.5, 1],
+      shadows = true,
+      effectsCapabilities = {},
+    } = config;
+
+    // If init is called again on the same instance, detach old listeners first.
+    if (this.surface) {
+      this.surface.unbindInput();
+      this.surface = null;
+    }
+    if (this.unbindResize) {
+      this.unbindResize();
+      this.unbindResize = null;
+    }
+
+    this.surface = surface;
 
     // Set asset base path
     if (basePath) {
@@ -87,19 +135,16 @@ export class GameScene {
       this.sceneGroup.add(this.characters.getGroup());
     }
 
-    // Create WebGL renderer (WebGPU support to be added when Three.js stabilizes the API)
-    this.renderer = new THREE.WebGLRenderer({
-      canvas,
-      antialias: true,
-      alpha: false,
-    });
+    const rendererFactory = this.dependencies.createRenderer ?? createDefaultRenderer;
+    this.renderer = rendererFactory(surface);
 
+    const size = surface.getSize();
     const dpr = Math.min(
-      Math.max(window.devicePixelRatio, pixelRatio[0]),
+      Math.max(surface.getDevicePixelRatio(), pixelRatio[0]),
       pixelRatio[1]
     );
     this.renderer.setPixelRatio(dpr);
-    this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+    this.renderer.setSize(size.width, size.height);
     this.renderer.outputColorSpace = THREE.SRGBColorSpace;
     this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
     this.renderer.toneMappingExposure = 1;
@@ -110,7 +155,8 @@ export class GameScene {
     }
 
     // Camera
-    this.controls = new CameraController(canvas);
+    const cameraControllerFactory = this.dependencies.createCameraController ?? createDefaultCameraController;
+    this.controls = cameraControllerFactory(surface);
     this.camera = this.controls.camera;
 
     // Re-render when camera moves (orbit, pan, zoom)
@@ -123,22 +169,21 @@ export class GameScene {
 
     // Post-processing
     this.effects.init(this.renderer, this.scene, this.camera, this.renderProfile);
+    this.effects.setCapabilities(effectsCapabilities);
 
     // Preload assets
     await this.assets.preloadAll();
 
     // Handle resize
-    this.resizeObserver = new ResizeObserver(() => {
-      const w = canvas.clientWidth;
-      const h = canvas.clientHeight;
-      this.renderer.setSize(w, h);
-      this.controls.resize(w, h);
-      this.effects.resize(w, h);
+    this.unbindResize = surface.onResize(() => {
+      const nextSize = surface.getSize();
+      this.renderer.setSize(nextSize.width, nextSize.height);
+      this.controls.resize(nextSize.width, nextSize.height);
+      this.effects.resize(nextSize.width, nextSize.height);
       this.requestRender();
     });
-    this.resizeObserver.observe(canvas);
 
-    this.setupInteraction(canvas);
+    this.setupInteraction(surface);
   }
 
   private setupLighting(): void {
@@ -193,41 +238,23 @@ export class GameScene {
     }
   }
 
-  private setupInteraction(canvas: HTMLCanvasElement): void {
-    this.interactionCanvas = canvas;
-
-    this.boundPointerDown = (e: PointerEvent) => {
-      if (e.button === 0) {
-        this.pointerDownPos = { x: e.clientX, y: e.clientY };
+  private setupInteraction(surface: RenderSurfaceAdapter): void {
+    const toNdc = (event: SurfaceInputEvent): { x: number; y: number } | null => {
+      const size = surface.getSize();
+      if (size.width <= 0 || size.height <= 0) {
+        return null;
       }
-    };
 
-    this.boundPointerUp = (e: PointerEvent) => {
-      if (e.button === 0 && this.pointerDownPos) {
-        const up = { x: e.clientX, y: e.clientY };
-        if (isClick(this.pointerDownPos, up, CLICK_THRESHOLD)) {
-          const rect = canvas.getBoundingClientRect();
-          const ndc = {
-            x: ((e.clientX - rect.left) / rect.width) * 2 - 1,
-            y: -((e.clientY - rect.top) / rect.height) * 2 + 1,
-          };
-          // Ensure camera matrix is fresh (OrbitControls may have updated between frames)
-          this.camera.updateMatrixWorld();
-          const grid = screenToGrid(ndc, this.camera, this.sceneGroup.matrixWorld, 3);
-          if (grid && this.onTileClickCallback) {
-            this.onTileClickCallback(grid.x, grid.y);
-          }
-        }
-        this.pointerDownPos = null;
-      }
-    };
-
-    this.boundPointerMove = createThrottled((e: PointerEvent) => {
-      const rect = canvas.getBoundingClientRect();
-      const ndc = {
-        x: ((e.clientX - rect.left) / rect.width) * 2 - 1,
-        y: -((e.clientY - rect.top) / rect.height) * 2 + 1,
+      return {
+        x: (event.x / size.width) * 2 - 1,
+        y: -(event.y / size.height) * 2 + 1,
       };
+    };
+
+    const handlePointerMove = createThrottled((event: SurfaceInputEvent) => {
+      const ndc = toNdc(event);
+      if (!ndc) return;
+
       this.camera.updateMatrixWorld();
       const grid = screenToGrid(ndc, this.camera, this.sceneGroup.matrixWorld, 3);
       if (grid) {
@@ -237,14 +264,47 @@ export class GameScene {
       }
     }, 50); // ~20fps throttle
 
-    this.boundPointerLeave = () => {
-      this.onHoverLeaveCallback?.();
+    this.boundInputHandler = (event: SurfaceInputEvent) => {
+      if (event.type === "pointerdown") {
+        if ((event.button ?? 0) === 0) {
+          this.pointerDownPos = { x: event.x, y: event.y };
+        }
+        return;
+      }
+
+      if (event.type === "pointerup") {
+        if ((event.button ?? 0) === 0 && this.pointerDownPos) {
+          const up = { x: event.x, y: event.y };
+          if (isClick(this.pointerDownPos, up, CLICK_THRESHOLD)) {
+            const ndc = toNdc(event);
+            if (!ndc) {
+              this.pointerDownPos = null;
+              return;
+            }
+
+            // Ensure camera matrix is fresh (controls may have updated between frames)
+            this.camera.updateMatrixWorld();
+            const grid = screenToGrid(ndc, this.camera, this.sceneGroup.matrixWorld, 3);
+            if (grid && this.onTileClickCallback) {
+              this.onTileClickCallback(grid.x, grid.y);
+            }
+          }
+          this.pointerDownPos = null;
+        }
+        return;
+      }
+
+      if (event.type === "pointermove") {
+        handlePointerMove(event);
+        return;
+      }
+
+      if (event.type === "pointerleave") {
+        this.onHoverLeaveCallback?.();
+      }
     };
 
-    canvas.addEventListener("pointerdown", this.boundPointerDown);
-    canvas.addEventListener("pointerup", this.boundPointerUp);
-    canvas.addEventListener("pointermove", this.boundPointerMove);
-    canvas.addEventListener("pointerleave", this.boundPointerLeave);
+    surface.bindInput(this.boundInputHandler);
   }
 
   onTileClick(cb: ((gridX: number, gridY: number) => void) | null): void {
@@ -351,7 +411,7 @@ export class GameScene {
     const animate = () => {
       this.animationId = requestAnimationFrame(animate);
 
-      // OrbitControls.update() returns true while damping is active
+      // controls.update() returns true while damping is active
       const controlsChanged = this.controls.update();
       if (controlsChanged) {
         this.needsRender = true;
@@ -388,18 +448,14 @@ export class GameScene {
 
   /** Cleanup all resources */
   dispose(): void {
-    // Remove interaction listeners
-    if (this.interactionCanvas) {
-      if (this.boundPointerDown) this.interactionCanvas.removeEventListener("pointerdown", this.boundPointerDown);
-      if (this.boundPointerUp) this.interactionCanvas.removeEventListener("pointerup", this.boundPointerUp);
-      if (this.boundPointerMove) this.interactionCanvas.removeEventListener("pointermove", this.boundPointerMove);
-      if (this.boundPointerLeave) this.interactionCanvas.removeEventListener("pointerleave", this.boundPointerLeave);
-      this.interactionCanvas = null;
+    if (this.surface) {
+      this.surface.unbindInput();
+      this.surface = null;
     }
 
-    if (this.resizeObserver) {
-      this.resizeObserver.disconnect();
-      this.resizeObserver = null;
+    if (this.unbindResize) {
+      this.unbindResize();
+      this.unbindResize = null;
     }
 
     this.stop();

--- a/packages/renderer/src/core/NativeCameraController.ts
+++ b/packages/renderer/src/core/NativeCameraController.ts
@@ -1,0 +1,80 @@
+import * as THREE from "three";
+import type { BoardBounds, CameraMode } from "./types";
+
+export interface NativeCameraControllerConfig {
+  minDistance?: number;
+  maxDistance?: number;
+  initialDistance?: number;
+}
+
+const DEFAULT_CONFIG: Required<NativeCameraControllerConfig> = {
+  minDistance: 5,
+  maxDistance: 300,
+  initialDistance: 24,
+};
+
+export class NativeCameraController {
+  private static readonly BOARD_MARGIN = 6;
+
+  readonly target = new THREE.Vector3(0, 0, 0);
+
+  private readonly minDistance: number;
+  private readonly maxDistance: number;
+  private distance: number;
+  private mode: CameraMode = "play";
+  private boardBounds: BoardBounds | null = null;
+
+  constructor(config: NativeCameraControllerConfig = {}) {
+    const resolved = { ...DEFAULT_CONFIG, ...config };
+    this.minDistance = resolved.minDistance;
+    this.maxDistance = resolved.maxDistance;
+    this.distance = THREE.MathUtils.clamp(
+      resolved.initialDistance,
+      this.minDistance,
+      this.maxDistance,
+    );
+  }
+
+  setMode(mode: CameraMode): void {
+    this.mode = mode;
+  }
+
+  getMode(): CameraMode {
+    return this.mode;
+  }
+
+  setBoardBounds(bounds: BoardBounds | null): void {
+    this.boardBounds = bounds;
+  }
+
+  applyPan(dx: number, dy: number): void {
+    this.target.x += dx;
+    this.target.z += dy;
+
+    if (this.mode !== "play" || !this.boardBounds) {
+      return;
+    }
+
+    const minX = this.boardBounds.minX - NativeCameraController.BOARD_MARGIN;
+    const maxX = this.boardBounds.maxX + NativeCameraController.BOARD_MARGIN;
+    const minZ = this.boardBounds.minZ - NativeCameraController.BOARD_MARGIN;
+    const maxZ = this.boardBounds.maxZ + NativeCameraController.BOARD_MARGIN;
+
+    this.target.x = THREE.MathUtils.clamp(this.target.x, minX, maxX);
+    this.target.z = THREE.MathUtils.clamp(this.target.z, minZ, maxZ);
+  }
+
+  applyPinch(scale: number): void {
+    if (scale <= 0) return;
+
+    this.distance = THREE.MathUtils.clamp(
+      this.distance / scale,
+      this.minDistance,
+      this.maxDistance,
+    );
+  }
+
+  getDistance(): number {
+    return this.distance;
+  }
+}

--- a/packages/renderer/src/core/NativeSurfaceAdapter.ts
+++ b/packages/renderer/src/core/NativeSurfaceAdapter.ts
@@ -1,0 +1,45 @@
+import type {
+  RenderSurfaceAdapter,
+  SurfaceInputEvent,
+  SurfaceSize,
+} from "./types";
+
+export interface NativeSurfaceHost {
+  getSize(): SurfaceSize;
+  getDevicePixelRatio(): number;
+  onResize(cb: () => void): () => void;
+  setInputHandler(handler: ((event: SurfaceInputEvent) => void) | null): void;
+  getRenderTarget?(): unknown;
+}
+
+export class NativeSurfaceAdapter implements RenderSurfaceAdapter {
+  private readonly host: NativeSurfaceHost;
+
+  constructor(host: NativeSurfaceHost) {
+    this.host = host;
+  }
+
+  getSize(): SurfaceSize {
+    return this.host.getSize();
+  }
+
+  getDevicePixelRatio(): number {
+    return this.host.getDevicePixelRatio();
+  }
+
+  onResize(cb: () => void): () => void {
+    return this.host.onResize(cb);
+  }
+
+  bindInput(handler: (event: SurfaceInputEvent) => void): void {
+    this.host.setInputHandler(handler);
+  }
+
+  unbindInput(): void {
+    this.host.setInputHandler(null);
+  }
+
+  getRenderTarget(): unknown {
+    return this.host.getRenderTarget?.();
+  }
+}

--- a/packages/renderer/src/core/WebSurfaceAdapter.ts
+++ b/packages/renderer/src/core/WebSurfaceAdapter.ts
@@ -1,0 +1,105 @@
+import type {
+  RenderSurfaceAdapter,
+  SurfaceInputEvent,
+  SurfaceSize,
+} from "./types";
+
+export class WebSurfaceAdapter implements RenderSurfaceAdapter {
+  private readonly canvas: HTMLCanvasElement;
+  private resizeObserver: ResizeObserver | null = null;
+  private inputHandler: ((event: SurfaceInputEvent) => void) | null = null;
+  private boundPointerDown: ((event: PointerEvent) => void) | null = null;
+  private boundPointerUp: ((event: PointerEvent) => void) | null = null;
+  private boundPointerMove: ((event: PointerEvent) => void) | null = null;
+  private boundPointerLeave: (() => void) | null = null;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+  }
+
+  getSize(): SurfaceSize {
+    return {
+      width: this.canvas.clientWidth,
+      height: this.canvas.clientHeight,
+    };
+  }
+
+  getDevicePixelRatio(): number {
+    return window.devicePixelRatio;
+  }
+
+  onResize(cb: () => void): () => void {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = new ResizeObserver(cb);
+    this.resizeObserver.observe(this.canvas);
+
+    return () => {
+      if (!this.resizeObserver) return;
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    };
+  }
+
+  bindInput(handler: (event: SurfaceInputEvent) => void): void {
+    this.unbindInput();
+    this.inputHandler = handler;
+
+    this.boundPointerDown = (event: PointerEvent) => {
+      this.emit("pointerdown", event);
+    };
+    this.boundPointerUp = (event: PointerEvent) => {
+      this.emit("pointerup", event);
+    };
+    this.boundPointerMove = (event: PointerEvent) => {
+      this.emit("pointermove", event);
+    };
+    this.boundPointerLeave = () => {
+      this.inputHandler?.({ type: "pointerleave", x: 0, y: 0 });
+    };
+
+    this.canvas.addEventListener("pointerdown", this.boundPointerDown);
+    this.canvas.addEventListener("pointerup", this.boundPointerUp);
+    this.canvas.addEventListener("pointermove", this.boundPointerMove);
+    this.canvas.addEventListener("pointerleave", this.boundPointerLeave);
+  }
+
+  unbindInput(): void {
+    if (this.boundPointerDown) {
+      this.canvas.removeEventListener("pointerdown", this.boundPointerDown);
+      this.boundPointerDown = null;
+    }
+    if (this.boundPointerUp) {
+      this.canvas.removeEventListener("pointerup", this.boundPointerUp);
+      this.boundPointerUp = null;
+    }
+    if (this.boundPointerMove) {
+      this.canvas.removeEventListener("pointermove", this.boundPointerMove);
+      this.boundPointerMove = null;
+    }
+    if (this.boundPointerLeave) {
+      this.canvas.removeEventListener("pointerleave", this.boundPointerLeave);
+      this.boundPointerLeave = null;
+    }
+    this.inputHandler = null;
+  }
+
+  getRenderTarget(): unknown {
+    return this.canvas;
+  }
+
+  private emit(type: SurfaceInputEvent["type"], event: PointerEvent): void {
+    if (!this.inputHandler) return;
+
+    const rect = this.canvas.getBoundingClientRect();
+    this.inputHandler({
+      type,
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+      button: event.button,
+    });
+  }
+}
+
+export function createWebSurfaceAdapter(canvas: HTMLCanvasElement): WebSurfaceAdapter {
+  return new WebSurfaceAdapter(canvas);
+}

--- a/packages/renderer/src/core/native-input-mapper.ts
+++ b/packages/renderer/src/core/native-input-mapper.ts
@@ -1,0 +1,127 @@
+export interface NativePointerEvent {
+  pointerId: number;
+  x: number;
+  y: number;
+}
+
+export type NativeMappedEvent =
+  | { type: "click"; x: number; y: number }
+  | { type: "pan"; dx: number; dy: number }
+  | { type: "pinch"; scale: number };
+
+export interface NativeInputMapperConfig {
+  clickThreshold?: number;
+}
+
+interface PointerState {
+  startX: number;
+  startY: number;
+  x: number;
+  y: number;
+}
+
+const DEFAULT_CONFIG: Required<NativeInputMapperConfig> = {
+  clickThreshold: 5,
+};
+
+function distance(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.hypot(dx, dy);
+}
+
+export class NativeInputMapper {
+  private readonly config: Required<NativeInputMapperConfig>;
+  private readonly pointers = new Map<number, PointerState>();
+  private dragDetected = false;
+  private lastPinchDistance: number | null = null;
+
+  constructor(config: NativeInputMapperConfig = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  handleStart(event: NativePointerEvent): NativeMappedEvent[] {
+    this.pointers.set(event.pointerId, {
+      startX: event.x,
+      startY: event.y,
+      x: event.x,
+      y: event.y,
+    });
+
+    if (this.pointers.size >= 2) {
+      this.dragDetected = true;
+      this.lastPinchDistance = this.getPinchDistance();
+    }
+
+    return [];
+  }
+
+  handleMove(event: NativePointerEvent): NativeMappedEvent[] {
+    const pointer = this.pointers.get(event.pointerId);
+    if (!pointer) return [];
+
+    const previous = { x: pointer.x, y: pointer.y };
+    pointer.x = event.x;
+    pointer.y = event.y;
+
+    if (this.pointers.size >= 2) {
+      const nextDistance = this.getPinchDistance();
+      if (!nextDistance || !this.lastPinchDistance || this.lastPinchDistance === 0) {
+        this.lastPinchDistance = nextDistance;
+        return [];
+      }
+
+      const scale = nextDistance / this.lastPinchDistance;
+      this.lastPinchDistance = nextDistance;
+      return [{ type: "pinch", scale }];
+    }
+
+    const start = { x: pointer.startX, y: pointer.startY };
+    if (distance(start, pointer) > this.config.clickThreshold) {
+      this.dragDetected = true;
+      return [{ type: "pan", dx: pointer.x - previous.x, dy: pointer.y - previous.y }];
+    }
+
+    return [];
+  }
+
+  handleEnd(event: NativePointerEvent): NativeMappedEvent[] {
+    const pointer = this.pointers.get(event.pointerId);
+    if (!pointer) return [];
+
+    pointer.x = event.x;
+    pointer.y = event.y;
+
+    const isTap = !this.dragDetected && distance(
+      { x: pointer.startX, y: pointer.startY },
+      { x: pointer.x, y: pointer.y },
+    ) <= this.config.clickThreshold;
+
+    this.pointers.delete(event.pointerId);
+
+    if (this.pointers.size < 2) {
+      this.lastPinchDistance = null;
+    }
+
+    if (this.pointers.size === 0) {
+      const shouldEmitClick = isTap;
+      this.dragDetected = false;
+      return shouldEmitClick ? [{ type: "click", x: event.x, y: event.y }] : [];
+    }
+
+    return [];
+  }
+
+  reset(): void {
+    this.pointers.clear();
+    this.dragDetected = false;
+    this.lastPinchDistance = null;
+  }
+
+  private getPinchDistance(): number | null {
+    const values = Array.from(this.pointers.values());
+    if (values.length < 2) return null;
+
+    return distance(values[0], values[1]);
+  }
+}

--- a/packages/renderer/src/core/render-profiles.ts
+++ b/packages/renderer/src/core/render-profiles.ts
@@ -1,4 +1,4 @@
-import type { CameraMode, RenderProfile } from "./types";
+import type { CameraMode, RenderProfile, EffectsCapabilities } from "./types";
 
 export interface LightingProfile {
   backgroundColor: number;
@@ -90,4 +90,37 @@ export function getLightingProfile(profile: RenderProfile): LightingProfile {
 
 export function getEffectsProfile(profile: RenderProfile): EffectsProfile {
   return EFFECTS_PROFILES[profile];
+}
+
+export function resolveEffectsProfile(
+  profile: RenderProfile,
+  capabilities: EffectsCapabilities = {},
+): EffectsProfile {
+  const base = getEffectsProfile(profile);
+  const resolved: EffectsProfile = {
+    bloom: { ...base.bloom },
+    vignette: { ...base.vignette },
+    ssao: { ...base.ssao },
+  };
+
+  if (capabilities.supportsSSAO === false) {
+    resolved.ssao.enabled = false;
+  }
+  if (capabilities.supportsBloom === false) {
+    resolved.bloom.strength = 0;
+    resolved.bloom.radius = 0;
+  }
+  if (capabilities.supportsVignette === false) {
+    resolved.vignette.offset = 0;
+    resolved.vignette.darkness = 0;
+  }
+
+  if (capabilities.lowPowerDevice) {
+    resolved.ssao.enabled = false;
+    resolved.bloom.strength *= 0.45;
+    resolved.bloom.radius *= 0.6;
+    resolved.vignette.darkness *= 0.5;
+  }
+
+  return resolved;
 }

--- a/packages/renderer/src/core/types.ts
+++ b/packages/renderer/src/core/types.ts
@@ -14,10 +14,45 @@ export interface BoardBounds {
 }
 
 export interface RendererConfig {
-  canvas: HTMLCanvasElement;
+  surface: RenderSurfaceAdapter;
   basePath?: string;
   pixelRatio?: [number, number];
   shadows?: boolean;
+  effectsCapabilities?: EffectsCapabilities;
+}
+
+export interface SurfaceSize {
+  width: number;
+  height: number;
+}
+
+export type SurfaceInputEventType =
+  | "pointerdown"
+  | "pointerup"
+  | "pointermove"
+  | "pointerleave";
+
+export interface SurfaceInputEvent {
+  type: SurfaceInputEventType;
+  x: number;
+  y: number;
+  button?: number;
+}
+
+export interface RenderSurfaceAdapter {
+  getSize(): SurfaceSize;
+  getDevicePixelRatio(): number;
+  onResize(cb: () => void): () => void;
+  bindInput(handler: (event: SurfaceInputEvent) => void): void;
+  unbindInput(): void;
+  getRenderTarget?(): unknown;
+}
+
+export interface EffectsCapabilities {
+  supportsBloom?: boolean;
+  supportsVignette?: boolean;
+  supportsSSAO?: boolean;
+  lowPowerDevice?: boolean;
 }
 
 export interface TileRenderData extends TileData {

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1,13 +1,19 @@
 // Core
 export { GameScene } from "./core/GameScene";
+export type { GameSceneDependencies } from "./core/GameScene";
 export { TileRenderer } from "./core/TileRenderer";
 export { CharRenderer } from "./core/CharRenderer";
 export { CameraController } from "./core/CameraController";
 export type { CameraConfig } from "./core/CameraController";
+export { NativeCameraController } from "./core/NativeCameraController";
+export { NativeInputMapper } from "./core/native-input-mapper";
+export { NativeSurfaceAdapter } from "./core/NativeSurfaceAdapter";
+export type { NativeSurfaceHost } from "./core/NativeSurfaceAdapter";
 export { AssetLoader } from "./core/AssetLoader";
 export { Effects } from "./core/Effects";
 export type { EffectsConfig } from "./core/Effects";
 export { BoxRainScene } from "./core/BoxRainScene";
+export { WebSurfaceAdapter, createWebSurfaceAdapter } from "./core/WebSurfaceAdapter";
 
 // Types
 export type {
@@ -15,6 +21,11 @@ export type {
   RenderProfile,
   BoardBounds,
   RendererConfig,
+  EffectsCapabilities,
+  RenderSurfaceAdapter,
+  SurfaceInputEvent,
+  SurfaceInputEventType,
+  SurfaceSize,
   TileRenderData,
   CharacterRenderData,
   HoverState,

--- a/packages/renderer/src/react-native/GameCanvasNative.tsx
+++ b/packages/renderer/src/react-native/GameCanvasNative.tsx
@@ -1,14 +1,16 @@
-import { useRef, useEffect } from "react";
-import { GameScene } from "../core/GameScene";
-import { createWebSurfaceAdapter } from "../core/WebSurfaceAdapter";
+import { useEffect, useRef } from "react";
+import { GameScene, type GameSceneDependencies } from "../core/GameScene";
 import type {
   TileRenderData,
   CharacterRenderData,
   HoverState,
   CameraMode,
+  RenderSurfaceAdapter,
+  EffectsCapabilities,
 } from "../core/types";
 
-export interface GameCanvasProps {
+export interface GameCanvasNativeProps {
+  surface: RenderSurfaceAdapter;
   tiles?: TileRenderData[];
   characters?: CharacterRenderData[];
   hover?: HoverState | null;
@@ -17,15 +19,17 @@ export interface GameCanvasProps {
   compassRotation?: number;
   cameraMode?: CameraMode;
   basePath?: string;
-  style?: React.CSSProperties;
-  className?: string;
+  effectsCapabilities?: EffectsCapabilities;
+  createRenderer?: GameSceneDependencies["createRenderer"];
+  createCameraController?: GameSceneDependencies["createCameraController"];
   onReady?: (scene: GameScene) => void;
   onTileClick?: (gridX: number, gridY: number) => void;
   onTileHover?: (gridX: number, gridY: number) => void;
   onHoverLeave?: () => void;
 }
 
-export function GameCanvas({
+export function GameCanvasNative({
+  surface,
   tiles = [],
   characters = [],
   hover = null,
@@ -34,14 +38,14 @@ export function GameCanvas({
   compassRotation = 0,
   cameraMode = "play",
   basePath = "",
-  style,
-  className,
+  effectsCapabilities,
+  createRenderer,
+  createCameraController,
   onReady,
   onTileClick,
   onTileHover,
   onHoverLeave,
-}: GameCanvasProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+}: GameCanvasNativeProps) {
   const sceneRef = useRef<GameScene | null>(null);
 
   const onTileClickRef = useRef(onTileClick);
@@ -53,25 +57,22 @@ export function GameCanvas({
   useEffect(() => { onHoverLeaveRef.current = onHoverLeave; }, [onHoverLeave]);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+    const scene = new GameScene({ createRenderer, createCameraController });
+    sceneRef.current = scene;
 
-    const gameScene = new GameScene();
-    sceneRef.current = gameScene;
-
-    gameScene.init({ surface: createWebSurfaceAdapter(canvas), basePath }).then(() => {
-      gameScene.onTileClick((gx, gy) => onTileClickRef.current?.(gx, gy));
-      gameScene.onTileHover((gx, gy) => onTileHoverRef.current?.(gx, gy));
-      gameScene.onHoverLeave(() => onHoverLeaveRef.current?.());
-      gameScene.start();
-      onReady?.(gameScene);
+    scene.init({ surface, basePath, effectsCapabilities }).then(() => {
+      scene.onTileClick((gx, gy) => onTileClickRef.current?.(gx, gy));
+      scene.onTileHover((gx, gy) => onTileHoverRef.current?.(gx, gy));
+      scene.onHoverLeave(() => onHoverLeaveRef.current?.());
+      scene.start();
+      onReady?.(scene);
     });
 
     return () => {
-      gameScene.dispose();
+      scene.dispose();
       sceneRef.current = null;
     };
-  }, [basePath]);
+  }, [surface, basePath, createRenderer, createCameraController, effectsCapabilities]);
 
   useEffect(() => {
     sceneRef.current?.updateTiles(tiles);
@@ -101,11 +102,5 @@ export function GameCanvas({
     sceneRef.current?.setCameraMode(cameraMode);
   }, [cameraMode]);
 
-  return (
-    <canvas
-      ref={canvasRef}
-      style={{ width: "100%", height: "100%", ...style }}
-      className={className}
-    />
-  );
+  return null;
 }

--- a/packages/renderer/src/react-native/index.ts
+++ b/packages/renderer/src/react-native/index.ts
@@ -1,0 +1,2 @@
+export { GameCanvasNative } from "./GameCanvasNative";
+export type { GameCanvasNativeProps } from "./GameCanvasNative";

--- a/packages/renderer/src/react/useScene.ts
+++ b/packages/renderer/src/react/useScene.ts
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useState } from "react";
 import { GameScene } from "../core/GameScene";
+import { createWebSurfaceAdapter } from "../core/WebSurfaceAdapter";
 import type { RendererConfig } from "../core/types";
 
 export function useScene(config?: Partial<RendererConfig>) {
@@ -14,7 +15,7 @@ export function useScene(config?: Partial<RendererConfig>) {
     const scene = new GameScene();
     sceneRef.current = scene;
 
-    scene.init({ canvas, ...config }).then(() => {
+    scene.init({ surface: createWebSurfaceAdapter(canvas), ...config }).then(() => {
       scene.start();
       setReady(true);
     });

--- a/react-native-threejs-tdd-prd.md
+++ b/react-native-threejs-tdd-prd.md
@@ -1,0 +1,322 @@
+# React Native Three.js Adaptation - TDD PRD
+
+## Document Control
+- Owner: Platform + Client Engineering
+- Status: In progress
+- Last updated: February 26, 2026
+- Target stack: `packages/*` monorepo only (`app/` is deprecated)
+
+## 1. Problem Statement
+`@paved/renderer` is currently web-canvas coupled and blocks a React Native client rollout.
+
+Current blockers in the renderer package:
+- `HTMLCanvasElement` is a hard requirement in renderer config (`packages/renderer/src/core/types.ts`).
+- DOM canvas mounting is required in React entrypoint (`packages/renderer/src/react/GameCanvas.tsx`).
+- Browser APIs are used in core scene lifecycle (`window.devicePixelRatio`, `ResizeObserver`, pointer events in `GameScene`).
+- Camera controls depend on DOM-bound `OrbitControls` (`packages/renderer/src/core/CameraController.ts`).
+
+We need a native-ready renderer path that preserves game behavior and interaction semantics without destabilizing web.
+
+## 2. Product Goal
+Deliver a React Native renderer path that:
+1. Runs the board in real-time on iOS and Android.
+2. Preserves gameplay-critical behavior (tile targeting, placement previews, camera mode semantics).
+3. Maintains web parity via shared core logic.
+4. Is implemented test-first (strict TDD) with objective performance and stability gates.
+
+## 3. Non-Goals (Phase 1)
+- Perfect visual parity for all post-processing effects (SSAO/bloom/vignette).
+- Migrating all web UI/flows in a single PR.
+- Rewriting core game domain packages (`@paved/game-core`, `@paved/chain`, `@paved/ui`) unless tests show hard native incompatibility.
+
+## 4. Success Criteria
+### Functional
+- User can open game scene on iOS and Android.
+- User can pan/zoom camera and toggle `play/showcase` mode.
+- User can tap a tile location and receive the same grid coordinate mapping semantics as web.
+- Hover/preview logic is adapted to touch semantics (tap-hold/selection preview) with no false placements.
+
+### Quality
+- Crash-free during 30-minute continuous session on both platforms.
+- No memory growth trend after repeated load/unload cycles.
+- p95 frame time under 25ms on reference mid-tier device (>=40 FPS p95).
+
+### Delivery
+- All new behavior lands with failing tests first and documented RED->GREEN evidence in PR.
+- Existing web tests remain green.
+
+## 5. Users and Use Cases
+### Primary users
+- Existing web players moving to mobile.
+
+### Core use cases
+- Join/open active game.
+- Place and rotate tile with accurate targeting.
+- Place character markers with same gameplay rules.
+- Switch camera mode for precise placement vs cinematic browse.
+
+## 6. Constraints and Assumptions
+- Monorepo remains Bun + Turbo managed.
+- Active development remains in `packages/*`.
+- Web client (`packages/app-web`) must not regress during migration.
+- Native package will be introduced as `packages/app-native`.
+
+## 7. Proposed Architecture (Target State)
+## 7.1 High-level plan
+Split renderer into:
+- Platform-agnostic core (`scene graph, math, tile/char rendering, rules-driven visuals`).
+- Platform adapters (`surface lifecycle, input events, resize/dpr, camera gesture plumbing`).
+
+## 7.2 Modules to keep shared
+- `TileRenderer`
+- `CharRenderer`
+- `interaction.ts` pure math helpers (`screenToGrid`, `isClick`, throttling utility)
+- Render profile logic
+
+## 7.3 Modules to refactor for platform abstraction
+- `RendererConfig` and canvas type in `core/types.ts`.
+- `GameScene.init` surface lifecycle and resize handling.
+- Input wiring in `GameScene.setupInteraction`.
+- `CameraController` (DOM `OrbitControls` coupling).
+
+## 7.4 Native entrypoint
+Add native renderer entrypoint in `@paved/renderer`:
+- `src/react-native/GameCanvasNative.tsx`.
+- Export map path `@paved/renderer/react-native`.
+
+## 7.5 Native app package
+Add `packages/app-native` (Expo) that consumes:
+- `@paved/game-core`
+- `@paved/chain`
+- `@paved/ui`
+- `@paved/renderer/react-native`
+
+## 8. TDD Strategy
+## 8.1 TDD law for this project
+No production adaptation code without a failing test first.
+
+For each story:
+1. Write minimal failing test.
+2. Run targeted test and capture expected failure reason.
+3. Write minimum code to pass.
+4. Run targeted suite + regression suites.
+5. Refactor only with green tests.
+
+## 8.2 Test pyramid
+- Unit tests (majority): platform abstractions, math, gesture translation, lifecycle behavior.
+- Integration tests: scene init/update/dispose with fake native surface adapter.
+- Device smoke/E2E: launch, render, interact, and recover across background/foreground.
+
+## 8.3 New test suites to add
+Renderer package:
+- [x] `packages/renderer/__tests__/surface-adapter.test.ts`
+- [x] `packages/renderer/__tests__/native-input-mapper.test.ts`
+- [x] `packages/renderer/__tests__/game-scene-native-lifecycle.test.ts`
+- [x] `packages/renderer/__tests__/camera-controller-native.test.ts`
+- [x] `packages/renderer/__tests__/effects-profile-fallback.test.ts`
+
+Native app package:
+- [x] `packages/app-native/__tests__/game-screen-render.test.tsx`
+- [x] `packages/app-native/__tests__/game-screen-interaction.test.tsx`
+- [x] `packages/app-native/__tests__/resume-recovery.test.tsx`
+
+## 8.4 Definition of RED evidence in PR
+Each task PR must include:
+- Command run for failing test.
+- Short failure excerpt proving behavior was missing.
+- Command run for passing test after implementation.
+
+## 9. Delivery Plan (TDD Epics)
+## Epic 0 - Baseline and Safety Nets
+Goal: lock current behavior before adaptation.
+
+Stories:
+1. Add characterization tests for current web `GameScene` lifecycle and click mapping.
+2. Add regression test for camera mode semantics (`play` clamps / `showcase` freer orbit).
+3. Add perf harness stub for scene update timing.
+
+Acceptance:
+- Web renderer suite remains green.
+- Baseline outputs committed for later comparison.
+
+## Epic 1 - Platform Abstraction Layer
+Goal: make core scene platform-neutral without changing behavior.
+
+Design:
+- Introduce `RenderSurfaceAdapter` interface:
+  - getSize()
+  - getDevicePixelRatio()
+  - onResize(cb)
+  - bindInput(handler)
+  - unbindInput()
+- Introduce `CameraInputAdapter` interface to decouple from `OrbitControls`.
+
+TDD stories:
+1. RED: `GameScene` can initialize with adapter interface instead of `HTMLCanvasElement`.
+2. RED: Resize callback updates renderer and camera from adapter values.
+3. RED: Input events mapped through adapter still call tile click/hover callbacks.
+4. RED: Disposal unregisters all adapter listeners.
+
+Acceptance:
+- Existing web path works via `WebSurfaceAdapter`.
+- No DOM types in public core config contracts.
+
+## Epic 2 - Native Input + Camera Controls
+Goal: recreate interaction semantics on touch devices.
+
+Design:
+- Implement native gesture mapping:
+  - single tap -> tile click candidate
+  - drag -> pan camera
+  - pinch -> dolly/zoom
+  - two-finger rotate optional in showcase mode
+- Preserve click-vs-drag threshold logic equivalent to `isClick` behavior.
+
+TDD stories:
+1. RED: tap within threshold produces click event.
+2. RED: drag beyond threshold suppresses click and pans camera target.
+3. RED: pinch updates camera distance within min/max bounds.
+4. RED: `play` and `showcase` mode constraints match web semantic tests.
+
+Acceptance:
+- Grid targeting parity against existing `screenToGrid` test vectors.
+- Gesture conflicts (pan vs tap) are deterministic and tested.
+
+## Epic 3 - Native Scene Rendering MVP
+Goal: render full board and character data on RN.
+
+Design:
+- Create `GameCanvasNative` wrapper and native scene host.
+- Start with effects fallback profile (no SSAO/bloom/vignette if unsupported/unstable).
+- Keep tile and character mesh generation shared.
+
+TDD stories:
+1. RED: native canvas host mounts and initializes `GameScene` once.
+2. RED: tile updates render expected mesh count transitions.
+3. RED: character updates render expected marker count transitions.
+4. RED: unmount disposes renderer/assets and no retained listeners remain.
+
+Acceptance:
+- iOS and Android smoke pass on physical device.
+- No crash on mount/unmount loop (50 cycles).
+
+## Epic 4 - App Integration (`packages/app-native`)
+Goal: playable mobile game loop integrated with shared packages.
+
+Design:
+- Native `GameScreen` analog to web `GamePage`.
+- Reuse store/actions from `@paved/ui` and `@paved/chain`.
+- Adapt hover-centric UX to touch selection UX.
+
+TDD stories:
+1. RED: scene receives tile/character state from store updates.
+2. RED: tap selects target tile and updates store coordinates.
+3. RED: confirm action produces optimistic tile and clears on failure.
+4. RED: camera mode toggle updates renderer mode.
+
+Acceptance:
+- End-to-end placement loop works in dev environment.
+- No regressions in shared package tests.
+
+## Epic 5 - Performance and Reliability Hardening
+Goal: ensure production viability.
+
+TDD stories:
+1. RED: frame budget guard fails when update workload exceeds threshold in perf harness.
+2. RED: background/foreground transition loses GL context without recovery.
+3. RED: memory leak sentinel fails after repeated load/dispose.
+4. RED: fallback effects profile engages on low-capability device flag.
+
+Acceptance:
+- Meets p95 frame and stability metrics.
+- Production readiness checklist signed off.
+
+## 10. Detailed Test Cases
+## 10.1 Core math parity
+- `screenToGrid` same outputs for shared fixtures across web/native camera matrices.
+- Compass rotation compensation unchanged.
+- Edge cases: near parallel ray, extreme zoom, negative coordinates.
+
+## 10.2 Interaction correctness
+- Tap-down/up within threshold emits one click.
+- Drag emits zero click and updates camera target.
+- Hover replacement behavior under touch (selected tile preview) is deterministic.
+
+## 10.3 Lifecycle robustness
+- Scene init idempotence: no double binding.
+- Dispose fully tears down input and resize handlers.
+- Context loss/recreation path restores scene without duplicated meshes.
+
+## 10.4 Rendering correctness
+- Tile add/remove diff updates mesh map correctly.
+- Pending tiles render pending style and clear when confirmed.
+- Character billboards orient to camera each frame.
+
+## 10.5 Cross-package integration
+- `@paved/chain` hooks update native screen without browser globals.
+- `@paved/ui` state transitions work in RN runtime.
+- `@paved/game-core` rules still drive placement validity.
+
+## 11. Implementation Backlog (Initial Ticket Breakdown)
+- [x] Add adapter interfaces and web adapter implementation.
+- [x] Refactor `GameScene` to adapter-based init.
+- [x] Add native adapter scaffolding with mocked tests.
+- [x] Add native camera controller implementation.
+- [x] Add `GameCanvasNative` entrypoint and exports.
+- [x] Create `packages/app-native` shell screen with renderer mount.
+- [x] Wire shared data flow (tiles/chars/camera mode).
+- [x] Add touch-based selection UX parity.
+- [ ] Add lifecycle recovery and perf instrumentation. (Lifecycle recovery implemented; perf instrumentation pending.)
+- [ ] Device validation and release checklist.
+
+## 12. Metrics and Observability
+Required instrumentation in native app:
+- Scene init duration (ms)
+- Asset preload duration (ms)
+- Average and p95 frame time
+- Gesture-to-action latency (tap to highlighted target)
+- GL context loss/recovery count
+- Crash-free session rate
+
+## 13. Risks and Mitigations
+1. Risk: Post-processing instability/perf on mobile GPUs.
+- Mitigation: default to reduced effects profile; gate heavy effects behind capability flag and tests.
+
+2. Risk: Orbit semantics mismatch on touch.
+- Mitigation: encode interaction semantics in tests (not implementation detail), then satisfy via native controller.
+
+3. Risk: Hidden web assumptions in shared code.
+- Mitigation: CI check for forbidden globals in shared packages and adapter boundaries.
+
+4. Risk: Asset loading path issues on RN bundle system.
+- Mitigation: asset resolver abstraction + integration tests with representative model/texture set.
+
+## 14. Rollout Plan
+Phase rollout:
+1. Internal feature flag (`nativeRendererV1`) in app-native dev builds.
+2. Dogfood with telemetry and perf gating.
+3. Beta cohort with crash/perf monitoring.
+4. General rollout once SLOs stable for two consecutive releases.
+
+Rollback:
+- Keep old fallback render mode (static board placeholder) for native if renderer initialization fails.
+
+## 15. PR Requirements Template
+Every implementation PR must include:
+- Scope mapped to one epic or smaller.
+- RED evidence (failing test command + failure reason).
+- GREEN evidence (passing command output summary).
+- Risk notes and follow-up tasks.
+- Explicit statement that web renderer regression suite passed.
+
+## 16. Open Decisions (Resolve Before Epic 2)
+1. Native rendering host choice and constraints (imperative Three host vs RN fiber host) based on spike results.
+2. Gesture library selection for deterministic pinch/pan/tap arbitration.
+3. Minimum supported device profile and performance budget targets by tier.
+4. Effects policy: parity-first vs performance-first defaults.
+
+## 17. Kickoff Checklist
+- [ ] Approve this PRD.
+- [ ] Create tracking epic with the five epics above.
+- [ ] Land Epic 0 characterization tests before any adaptation code.
+- [x] Start Epic 1 with adapter interface RED tests.


### PR DESCRIPTION
This PR adds a React Native-ready renderer path by introducing surface/input abstractions, refactoring GameScene off direct HTML canvas coupling, and adding native camera/input controllers plus effects capability fallbacks. It adds a new renderer native entrypoint (`@paved/renderer/react-native`) with `GameCanvasNative` and keeps the web path working through `WebSurfaceAdapter`. It also introduces `packages/app-native` with a `GameScreen` shell and tests for render wiring, touch selection callback behavior, and resume recovery rendering. The PR includes new renderer and app-native test suites plus PRD checklist updates, and the renderer/app-native test and build scripts pass in this workspace.